### PR TITLE
NGC-637 - Add caching HTTP response headers to NGC submission-tracker service

### DIFF
--- a/app/uk/gov/hmrc/submissiontracker/config/microserviceGlobal.scala
+++ b/app/uk/gov/hmrc/submissiontracker/config/microserviceGlobal.scala
@@ -25,11 +25,13 @@ import play.api._
 import uk.gov.hmrc.api.config.{ServiceLocatorConfig, ServiceLocatorRegistration}
 import uk.gov.hmrc.api.connector.ServiceLocatorConnector
 import uk.gov.hmrc.api.controllers._
+import uk.gov.hmrc.api.filters.CacheControlFilter
 import uk.gov.hmrc.submissiontracker.controllers._
 import uk.gov.hmrc.play.audit.filters.AuditFilter
 import uk.gov.hmrc.play.auth.controllers.AuthParamsControllerConfig
 import uk.gov.hmrc.play.auth.microservice.filters.AuthorisationFilter
 import uk.gov.hmrc.play.config.{AppName, ControllerConfig, RunMode}
+import uk.gov.hmrc.play.filters.NoCacheFilter
 import uk.gov.hmrc.play.http.HeaderCarrier
 import uk.gov.hmrc.play.http.logging.filters.LoggingFilter
 import uk.gov.hmrc.play.microservice.bootstrap.DefaultMicroserviceGlobal
@@ -75,6 +77,10 @@ object MicroserviceGlobal extends DefaultMicroserviceGlobal with RunMode with Se
   override val authFilter = Some(MicroserviceAuthFilter)
 
   override val slConnector: ServiceLocatorConnector = ServiceLocatorConnector(WSHttp)
+
+  val cacheFilter = CacheControlFilter.fromConfig(CacheControlFilter.configKey)
+
+  override val microserviceFilters = defaultMicroserviceFilters.filterNot( _.isInstanceOf[NoCacheFilter.type] ) :+ cacheFilter
 
   override implicit val hc: HeaderCarrier = HeaderCarrier()
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -144,6 +144,9 @@ auditing {
   }
 }
 
+apiCaching {
+  "/tracking/\\w+/\\w+" = 3600
+}
 
 microservice {
   metrics {

--- a/project/MicroServiceBuild.scala
+++ b/project/MicroServiceBuild.scala
@@ -30,7 +30,7 @@ private object AppDependencies {
   private val playUrlBindersVersion = "1.0.0"
   private val playConfigVersion = "2.0.1"
   private val domainVersion = "3.5.0"
-  private val playHmrcApiVersion = "0.5.0"
+  private val playHmrcApiVersion = "0.6.0"
 
   private val scalaTestVersion = "2.2.6"
   private val pegdownVersion = "1.6.0"


### PR DESCRIPTION
Allow /tracking endpoint response to be cached